### PR TITLE
Update yt-dlp to patched release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tafrigh[wit]==1.1.3
 ffmpeg-python
-yt-dlp==2023.7.6
+yt-dlp==2023.09.24
 pydub==0.25.1
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- bump yt-dlp to version 2023.09.24 to address upstream security advisories

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fea3aed5c832b8e0689fee22d9ad8)